### PR TITLE
Fix extraction of Message-IDs and fix function that sets the Thread-ID wrongly

### DIFF
--- a/pkg/R/mail.R
+++ b/pkg/R/mail.R
@@ -150,7 +150,7 @@ threads <- function(x)
                 for (i in 1:length(parentID)) {
                     info <- get.thread.id(parentID[[i]], ht)
                     if (!is.na(info$threadID))
-                        next
+                        break
                 }
             } else
                 info <- get.thread.id(parentID, ht)

--- a/pkg/R/mail.R
+++ b/pkg/R/mail.R
@@ -147,8 +147,8 @@ threads <- function(x)
 
             parentID <- unique(parentID)
             if (length(parentID) > 1) {
-                for (i in 1:length(parentID)) {
-                    info <- get.thread.id(parentID[[i]], ht)
+                for (j in 1:length(parentID)) {
+                    info <- get.thread.id(parentID[[j]], ht)
                     if (!is.na(info$threadID))
                         break
                 }

--- a/pkg/R/reader.R
+++ b/pkg/R/reader.R
@@ -29,6 +29,10 @@ function(DateFormat = "%d %B %Y %H:%M:%S")
         if (!length(mid)) {
             mid <- gsub("Message-Id: ", "",
                         grep("^Message-Id:", header, value = TRUE, useBytes = TRUE))
+            if (!length(mid)) {
+                mid <- gsub("Message-id: ", "",
+                            grep("^Message-id:", header, value = TRUE, useBytes = TRUE))
+            }
         }
         
         origin <- gsub("Newsgroups: ", "",

--- a/pkg/R/reader.R
+++ b/pkg/R/reader.R
@@ -40,7 +40,7 @@ function(DateFormat = "%d %B %Y %H:%M:%S")
         }
         
         ## if mid is empty string, then the actual Message-ID is given in the subsequent line
-        if (identical(mid, "") {
+        if (identical(mid, "")) {
             mid <- trimws(header[[grep(mid.key, header, value = FALSE, useBytes = TRUE) + 1]])
         }    
         

--- a/pkg/R/reader.R
+++ b/pkg/R/reader.R
@@ -26,6 +26,11 @@ function(DateFormat = "%d %B %Y %H:%M:%S")
                      tz = "GMT")
         mid <- gsub("Message-ID: ", "",
                     grep("^Message-ID:", header, value = TRUE, useBytes = TRUE))
+        if (!length(mid)) {
+            mid <- gsub("Message-Id: ", "",
+                        grep("^Message-Id:", header, value = TRUE, useBytes = TRUE))
+        }
+        
         origin <- gsub("Newsgroups: ", "",
                        grep("^Newsgroups:", header, value = TRUE, useBytes = TRUE))
         heading <- gsub("Subject: ", "",

--- a/pkg/R/reader.R
+++ b/pkg/R/reader.R
@@ -24,16 +24,25 @@ function(DateFormat = "%d %B %Y %H:%M:%S")
                           grep("^Date:", header, value = TRUE, useBytes = TRUE)),
                      format = format,
                      tz = "GMT")
+        
+        mid.key <- "^Message-ID:"
         mid <- gsub("Message-ID: ", "",
-                    grep("^Message-ID:", header, value = TRUE, useBytes = TRUE))
+                    grep(mid.key, header, value = TRUE, useBytes = TRUE))
         if (!length(mid)) {
+            mid.key <- "^Message-Id:"
             mid <- gsub("Message-Id: ", "",
-                        grep("^Message-Id:", header, value = TRUE, useBytes = TRUE))
+                        grep(mid.key, header, value = TRUE, useBytes = TRUE))
             if (!length(mid)) {
+                mid.key <- "^Message-id:"
                 mid <- gsub("Message-id: ", "",
-                            grep("^Message-id:", header, value = TRUE, useBytes = TRUE))
+                            grep(mid.key, header, value = TRUE, useBytes = TRUE))
             }
         }
+        
+        ## if mid is empty string, then the actual Message-ID is given in the subsequent line
+        if (identical(mid, "") {
+            mid <- trimws(header[[grep(mid.key, header, value = FALSE, useBytes = TRUE) + 1]])
+        }    
         
         origin <- gsub("Newsgroups: ", "",
                        grep("^Newsgroups:", header, value = TRUE, useBytes = TRUE))


### PR DESCRIPTION
In this PR, we fix two bugs which caused wrong data when identifying mail threads:

1. In some cases, the header field for message ids is not spelled as expected. Such mails just got a numeric message id, which means, that these mails could not be mapped to any references/reply-to-header in other messages, and are, thus, ignored in thread computation. (For instance, in qemu we identified roughly 28,500 mails for which the message id has not been extracted, which is quite a substantial number of e-mails. Including two spelling variants of `Message-ID`, namely `Message-Id` and `Message-id` decreased the number of such e-mails from 28,500 to 10). We provide a fix to cover these additional spelling variants if no header field spelled `Message-ID` is available.
2. Even when having extracted the "correct" Message-IDs, the thread computation contained two additional bugs:
- When there are multiple "In-Reply-To" fields, we iterate over them until we find a referenced message id in our hashtable. However, we need to `break` as soon as we found one, instead of calling `next` which could result in a not-available reference.
- If there are multiple "In-Reply-To" fields, we end up in unrelated mails having the same thread id (e.g., 0), as the thread id of the wrong e-mail is updated as the loop variable of the inner loop is called `i`, as also the loop variable of the outer loop is called. That is, when returning from the inner loop, the outer loop accesses `i` again but gets the last value of the inner loop instead of the current value of the outer loop, and, thus, is updating the wrong array element. We renamed the inner loop variable to `j` to avoid this problem.

[As Codeface installs `tm-plugin-mail` from your repository, this PR also acts as a direct bugfix to Codeface.]